### PR TITLE
Fix default BUCKET_URL to location.protocol

### DIFF
--- a/list.js
+++ b/list.js
@@ -3,7 +3,7 @@ if (typeof AUTO_TITLE != 'undefined' && AUTO_TITLE == true) {
 }
 
 if (typeof S3_REGION != 'undefined') {
-  var BUCKET_URL = 'http://' + location.hostname + '.' + S3_REGION + '.amazonaws.com'; // e.g. just 's3' for us-east-1 region
+  var BUCKET_URL = location.protocol + '//' + location.hostname + '.' + S3_REGION + '.amazonaws.com'; // e.g. just 's3' for us-east-1 region
   var BUCKET_WEBSITE_URL = location.protocol + '//' + location.hostname;
 }
 


### PR DESCRIPTION
When only specifying a region, the BUCKET_URL used for API calls should match browser protocol otherwise XHR will fail.